### PR TITLE
Implement JWT authentication filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/com/patrik/taskai/taskai_manager/config/DataInitializer.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/config/DataInitializer.java
@@ -1,0 +1,23 @@
+package com.patrik.taskai.taskai_manager.config;
+
+import com.patrik.taskai.taskai_manager.model.Role;
+import com.patrik.taskai.taskai_manager.model.RoleName;
+import com.patrik.taskai.taskai_manager.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final RoleRepository roleRepository;
+
+    @Override
+    public void run(String... args) {
+        for (RoleName roleName : RoleName.values()) {
+            roleRepository.findByName(roleName)
+                    .orElseGet(() -> roleRepository.save(new Role(null, roleName)));
+        }
+    }
+}

--- a/src/main/java/com/patrik/taskai/taskai_manager/config/JwtAuthFilter.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/config/JwtAuthFilter.java
@@ -1,0 +1,54 @@
+package com.patrik.taskai.taskai_manager.config;
+
+import com.patrik.taskai.taskai_manager.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String userEmail;
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        jwt = authHeader.substring(7);
+        userEmail = jwtService.extractUsername(jwt);
+
+        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
+            if (jwtService.isTokenValid(jwt, userDetails)) {
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/patrik/taskai/taskai_manager/config/SecurityConfig.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/config/SecurityConfig.java
@@ -1,16 +1,24 @@
 package com.patrik.taskai.taskai_manager.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,7 +34,8 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .httpBasic(); // or remove this later when using JWT
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/patrik/taskai/taskai_manager/controller/PrivateController.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/controller/PrivateController.java
@@ -1,0 +1,22 @@
+package com.patrik.taskai.taskai_manager.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class PrivateController {
+
+    @GetMapping("/private")
+    public String privateEndpoint() {
+        return "private";
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin")
+    public String adminEndpoint() {
+        return "admin";
+    }
+}

--- a/src/main/java/com/patrik/taskai/taskai_manager/model/Role.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/model/Role.java
@@ -1,6 +1,20 @@
 package com.patrik.taskai.taskai_manager.model;
 
-public enum Role {
-    USER,
-    ADMIN
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "roles")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RoleName name;
 }

--- a/src/main/java/com/patrik/taskai/taskai_manager/model/RoleName.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/model/RoleName.java
@@ -1,0 +1,6 @@
+package com.patrik.taskai.taskai_manager.model;
+
+public enum RoleName {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/patrik/taskai/taskai_manager/model/User.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/model/User.java
@@ -22,7 +22,8 @@ public class User {
     private String email;
     private String password;
 
-    @Enumerated(EnumType.STRING)
+    @ManyToOne
+    @JoinColumn(name = "role_id")
     private Role role;
 
 }

--- a/src/main/java/com/patrik/taskai/taskai_manager/repository/RoleRepository.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/repository/RoleRepository.java
@@ -1,0 +1,13 @@
+package com.patrik.taskai.taskai_manager.repository;
+
+import com.patrik.taskai.taskai_manager.model.Role;
+import com.patrik.taskai.taskai_manager.model.RoleName;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(RoleName name);
+}

--- a/src/main/java/com/patrik/taskai/taskai_manager/service/ApplicationUserDetailsService.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/service/ApplicationUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.patrik.taskai.taskai_manager.service;
+
+import com.patrik.taskai.taskai_manager.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        com.patrik.taskai.taskai_manager.model.User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return User.withUsername(user.getEmail())
+                .password(user.getPassword())
+                .roles(user.getRole().getName().name())
+                .build();
+    }
+}

--- a/src/main/java/com/patrik/taskai/taskai_manager/service/AuthService.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/service/AuthService.java
@@ -3,6 +3,8 @@ package com.patrik.taskai.taskai_manager.service;
 import com.patrik.taskai.taskai_manager.dto.LoginRequest;
 import com.patrik.taskai.taskai_manager.dto.RegisterRequest;
 import com.patrik.taskai.taskai_manager.model.Role;
+import com.patrik.taskai.taskai_manager.model.RoleName;
+import com.patrik.taskai.taskai_manager.repository.RoleRepository;
 import com.patrik.taskai.taskai_manager.model.User;
 import com.patrik.taskai.taskai_manager.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RoleRepository roleRepository;
 
     private final JwtService jwtService;
 
@@ -22,10 +25,12 @@ public class AuthService {
         if(userRepository.findByEmail(request.getEmail()).isPresent()){
             throw  new RuntimeException("User already exist");
         }
+        Role userRole = roleRepository.findByName(RoleName.USER)
+                .orElseThrow(() -> new RuntimeException("Default role missing"));
         User user = User.builder()
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
-                .role(Role.USER)
+                .role(userRole)
                 .build();
 
         userRepository.save(user);

--- a/src/main/java/com/patrik/taskai/taskai_manager/service/JwtService.java
+++ b/src/main/java/com/patrik/taskai/taskai_manager/service/JwtService.java
@@ -1,14 +1,16 @@
 package com.patrik.taskai.taskai_manager.service;
 
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
+import java.nio.charset.StandardCharsets;
 
 @Service
 public class JwtService {
@@ -24,8 +26,32 @@ public class JwtService {
                 .compact();
     }
 
+    public String extractUsername(String token) {
+        return extractAllClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        String username = extractUsername(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    public Date extractExpiration(String token) {
+        return extractAllClaims(token).getExpiration();
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSignInKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
     private Key getSignInKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
-        return Keys.hmacShaKeyFor(keyBytes);
+        return Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/com/patrik/taskai/taskai_manager/AuthServiceTest.java
+++ b/src/test/java/com/patrik/taskai/taskai_manager/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.patrik.taskai.taskai_manager;
 import com.patrik.taskai.taskai_manager.dto.LoginRequest;
 import com.patrik.taskai.taskai_manager.dto.RegisterRequest;
 import com.patrik.taskai.taskai_manager.model.Role;
+import com.patrik.taskai.taskai_manager.model.RoleName;
 import com.patrik.taskai.taskai_manager.model.User;
 import com.patrik.taskai.taskai_manager.repository.UserRepository;
 import com.patrik.taskai.taskai_manager.service.AuthService;
@@ -53,7 +54,7 @@ class AuthServiceTest {
     @Test
     void shouldLoginAndReturnJwtToken() {
         LoginRequest req = new LoginRequest("test@example.com", "password123");
-        User user = new User(10l,"test@example.com", "hashedPass", Role.USER);
+        User user = new User(10L, "test@example.com", "hashedPass", new Role(1L, RoleName.USER));
 
         when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("password123", "hashedPass")).thenReturn(true);


### PR DESCRIPTION
## Summary
- create `JwtAuthFilter` to validate bearer tokens and populate the security context
- implement `ApplicationUserDetailsService` to load users by email
- extend `JwtService` with token parsing utilities and expiry check
- clean duplicate dependencies in `pom.xml`
- wire the filter into `SecurityConfig`
- add role entities and admin-protected endpoint

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6851b9a3aa80832a9af213c47a1a90ce